### PR TITLE
ASRMAINT-979 Add CustomerNumber field to Customer

### DIFF
--- a/OpenTrack.Lib/Requests/CustomerAddRequest.cs
+++ b/OpenTrack.Lib/Requests/CustomerAddRequest.cs
@@ -57,6 +57,8 @@ namespace OpenTrack.Requests
 
     public class Customer
     {
+        public String CustomerNumber { get; set; }
+        
         public String TypeCode { get; set; }
 
         public String LastName { get; set; }


### PR DESCRIPTION
The `CustomerNumber` field is included in the wiki for the [OpenTrack CustomerUpdate Request](https://www.dealertrackdms.com/opentrack/index.php/CustomerUpdate_Request), but was not added to our `Customer` class.